### PR TITLE
Fix for WS2811 BRG led strip

### DIFF
--- a/microLED/ws2812_send.h
+++ b/microLED/ws2812_send.h
@@ -24,9 +24,9 @@
 #define ORDER1	1
 #define ORDER2	2
 #elif defined(ORDER_BRG)
-#define ORDER0	2
-#define ORDER1	0
-#define ORDER2	1
+#define ORDER0	1
+#define ORDER1	2
+#define ORDER2	0
 #else
 #define ORDER0	1
 #define ORDER1	0


### PR DESCRIPTION
лента на ws2811, по три светодиода последовательно в 12V.
при установленном #define ORDER_RGB загоралась в порядке B,R,G (вместо RGB)
установка #define ORDER_BRG приводила к порядку цветов G,B,R
установка #define ORDER_GRB -> R,B,G соответственно