### PR TITLE
Update directADC

### DIFF
--- a/directADC/directADC.cpp
+++ b/directADC/directADC.cpp
@@ -124,6 +124,21 @@ void ADC_setReference(ADC_modes ref) {
 	sei();
 }
 
+void ADC_setResolution(uint8_t res)
+{
+	cli();
+	switch(res)
+	{
+		case 10:
+			ADMUX &= ~(1<<ADLAR); // right adjustment
+			break;
+		case 8:
+			ADMUX |= (1<<ADLAR); //left adjustment
+			break;
+	}
+	sei();
+}
+
 /* Включить режим автозапуска АЦП и выбрать его источник. Внимание! Запуск преобразования начинается по ФРОНТУ (RISING) события */
 void ADC_autoTriggerEnable(ADC_modes trig) {
 	cli();
@@ -185,8 +200,12 @@ void ADC_startConvert() { // ручной запуск преобразован�
 	sei();
 }
 
-unsigned int ADC_read() { // склеить и вернуть значение ацп
-	return ADCL | (ADCH << 8); 
+unsigned int ADC_read() { // вернуть значение АЦП
+	return ADC;
+}
+
+uint8_t ADC_read8(void) { // вернуть 8-битное значение АЦП
+	return ADCH;
 }
 
 boolean ADC_available() { // проверить готовность АЦП
@@ -200,7 +219,12 @@ boolean ADC_available() { // проверить готовность АЦП
 
 unsigned int ADC_readWhenAvailable() { // дождаться окончания текущего преобразования,склеить и вернуть результат
 	while (ADCSRA & (1 << ADSC));
-	return ADCL | (ADCH << 8);
+	return ADC; 
+}
+
+uint8_t ADC_read8WhenAvailable(void) {
+	while (ADCSRA & (1 << ADSC));
+	return ADCH;
 }
 
 ISR(ADC_vect){ // прерывание ацп

--- a/directADC/directADC.h
+++ b/directADC/directADC.h
@@ -53,14 +53,17 @@ void ADC_enable(void);  				// Включить АЦП
 void ADC_disable(void);   				// Выключить АЦП (default)
 void ADC_setPrescaler(byte prescl);   	// Выбрать делитель частоты АЦП (2, 4, 8, 16, 32, 64, 128) // (default: 2)
 void ADC_setReference(ADC_modes ref);	// Выбрать источник опорного напряжения АЦП (ADC_1V1, ADC_AREF, ADC_VCC) // (default: ADC_AREF)
+void ADC_setResolution(uint8_t res);  // Выбрать разрядность АЦП (8, 10) // (default: 10)
 void ADC_autoTriggerEnable(ADC_modes trig); 	// Включить автозапуск АЦП и выбрать событие (FREE_RUN, ANALOG_COMP, ADC_INT0, TIMER0_COMPA, TIMER0_OVF, TIMER1_COMPB, TIMER1_OVF)
 void ADC_autoTriggerDisable(void);   	// Выключить автозапуск АЦП // (default)
 void ADC_attachInterrupt(void (*isr)());// Включить прерывание готовности АЦП и выбрать функцию, которая будет при этом выполняться
 void ADC_detachInterrupt(void);			// Выключить прерывание готовности АЦП // (default) 
 void ADC_startConvert(void);			// Ручной запуск преобразования
 unsigned int ADC_read(void);			// Прочитать значение регистров АЦП (Вызов до окончания преобразования вернет неверный результат)
+uint8_t ADC_read8(void);				// То же самое что ADC_read(), но возвращает 8-битный результат
 boolean ADC_available(void);			// Проверить готовность преобразования АЦП
 unsigned int ADC_readWhenAvailable(void);	// Дождаться окончания текущего преобразования и вернуть результат
+uint8_t ADC_read8WhenAvailable(void);	// То же самое что ADC_readWhenAvailable(), но возвращает 8-битный результат
 void ACOMP_attachInterrupt(void (*isr)(), ADC_modes source); // Включить прерывание компаратора и выбрать при каком событии оно будет вызвано (FALLING_TRIGGER, RISING_TRIGGER, CHANGE_TRIGGER)
 void ACOMP_detachInterrupt(void); 		// Выключить прерывание компаратора // (default)
 void ACOMP_enable(void); 				// Включить компаратор // (default: Включен)

--- a/directADC/examples/simple_adc_8bit/simple_adc_8bit.ino
+++ b/directADC/examples/simple_adc_8bit/simple_adc_8bit.ino
@@ -1,0 +1,16 @@
+#include <directADC.h>
+void setup() {
+  Serial.begin(9600);
+  ADC_enable();
+  ADC_setPrescaler(64);
+  ADC_setReference(ADC_VCC);
+  setAnalogMux(ADC_A0);
+  ADC_setResolution(8);
+}
+
+void loop() {
+  ADC_startConvert();
+  while(!ADC_available());
+  Serial.println(ADC_read8());
+  delay(10); 
+}

--- a/directADC/keywords.txt
+++ b/directADC/keywords.txt
@@ -16,13 +16,16 @@ ADC_disable	KEYWORD2
 ADC_autoTriggerEnable	KEYWORD2
 ADC_setPrescaler	KEYWORD2
 ADC_setReference	KEYWORD2
+ADC_setResolution	KEYWORD2
 ADC_autoTriggerDisable	KEYWORD2
 ADC_attachInterrupt	KEYWORD2
 ADC_detachInterrupt	KEYWORD2
 ADC_startConvert	KEYWORD2
 ADC_read	KEYWORD2
+ADC_read8	KEYWORD2
 ADC_available	KEYWORD2
 ADC_readWhenAvailable	KEYWORD2
+ADC_read8WhenAvailible	KEYWORD2
 ACOMP_attachInterrupt	KEYWORD2
 ACOMP_detachInterrupt	KEYWORD2
 ACOMP_enable	KEYWORD2

--- a/directADC/library.properties
+++ b/directADC/library.properties
@@ -1,5 +1,5 @@
 name=directADC
-version=1.0
+version=1.1
 author=AlexGyver <beragumbo@ya.ru>
 maintainer=AlexGyver <beragumbo@ya.ru>
 sentence=Library for advanced ADC control.


### PR DESCRIPTION
**Основные изменения**

- Добавлена возможность поменять разрешение АЦП на 8-битное. Новые функции:
  - ADC_setResolution(uint8_t res) - выбрать разрешение 10 или 8 бит;
  - ADC_read8(void) - возвращает 8-битный результат;
  - ADC_read8WhenAvailable(void) - дождаться окончания и вернуть 8-битный результат.
- Изменена склейка ADCL | (ADCH << 8) на ADC.

**Комментарии**
Для полного раскрытия возможностей АЦП атмеги328 необходимо все же добавить 8-битное разрешение, которое довольно юзабельно при высокой скорости оцифровки, для отсечения лишних шумов или более быстрой и емкой обработки результата (с 1 байтом попроще работать). 

В оригинальной библиотеке результат АЦП возвращается как ADCL | (ADCH << 8) , что на самом деле лишнее и добавляет пару лишних ассемблерных команд. Для доступа к результату АЦП оптимальнее использовать ADC. Для сравнения привел ниже ассемблерный код с записью результата АЦП в переменную x.
```
x=ADCL | (ADCH << 8); 
000004B0  LDS R24,0x0078	Load direct from data space 
000004B2  LDS R18,0x0079	Load direct from data space 
000004B4  LDI R25,0x00		Load immediate 
000004B5  OR R25,R18		Logical OR
00000086  STS 0x0123,R25	Store direct to data space 
00000088  STS 0x0122,R24	Store direct to data space 

x=ADC; 
000004B0  LDS R24,0x0078		Load direct from data space 
000004B2  LDS R25,0x0079		Load direct from data space
00000086  STS 0x0123,R25		Store direct to data space 
00000088  STS 0x0122,R24		Store direct to data space
```
