### PR TITLE
Инициализация неинициализированных членов классов

### DIFF
--- a/GyverBME280/GyverBME280.cpp
+++ b/GyverBME280/GyverBME280.cpp
@@ -161,7 +161,7 @@ void GyverBME280::oneMeasurement(void)
 	GyverBME280::writeRegister(0xF4 , ((GyverBME280::readRegister(0xF4) & 0xFC) | 0x02));   // Set the operating mode to FORCED_MODE
 }
 
-GyverBME280::GyverBME280() {}
+GyverBME280::GyverBME280() = default;
 
 
 

--- a/GyverBME280/GyverBME280.h
+++ b/GyverBME280/GyverBME280.h
@@ -96,7 +96,7 @@ private:
 		int16_t _H4;
 		int16_t _H5;
 		int8_t _H6;
-	} CalibrationData;
+	} CalibrationData {};
 
 };
 

--- a/GyverEncoder/GyverEncoder.h
+++ b/GyverEncoder/GyverEncoder.h
@@ -151,7 +151,7 @@ public:
 	void resetStates();						// сбрасывает все is-флаги и счётчики
 	
 private:
-	GyverEncoderFlags flags;
+	GyverEncoderFlags flags {};
 	uint8_t _fast_timeout = 50;				// таймаут быстрого поворота
 	uint8_t prevState = 0;
 	uint8_t encState = 0;	// 0 не крутился, 1 лево, 2 право, 3 лево нажат, 4 право нажат

--- a/GyverMotor/GyverMotor.h
+++ b/GyverMotor/GyverMotor.h
@@ -116,5 +116,5 @@ protected:
 	uint16_t _deadtime = 0;
 	uint8_t _speed = 20;
 	uint32_t _tmr = 0;
-	float _k;
+	float _k = 0.0;
 };

--- a/GyverTM1637/GyverTM1637.h
+++ b/GyverTM1637/GyverTM1637.h
@@ -64,7 +64,7 @@ public:
 	void twistByte(uint8_t bit0, uint8_t bit1, uint8_t bit2, uint8_t bit3, int delayms);	// скрутка посимвольно
 	
 private:
-	uint8_t lastData[4];
+	uint8_t lastData[4] {};
 	void update();
 	int  writeByte(int8_t wr_data);
 	void start(void);
@@ -73,10 +73,10 @@ private:
 	void sendByte(uint8_t BitAddr, int8_t sendData);
 	void sendArray(uint8_t sendData[]);
 
-	uint8_t Cmd_SetData;
-	uint8_t Cmd_SetAddr;
-	uint8_t Cmd_DispCtrl;
-	uint8_t PointData;
+	uint8_t Cmd_SetData = 0;
+	uint8_t Cmd_SetAddr = 0;
+	uint8_t Cmd_DispCtrl = 0;
+	uint8_t PointData = 0;
 
 	uint8_t Clkpin;
 	uint8_t Datapin;	

--- a/microLiquidCrystal_I2C/microLiquidCrystal_I2C.h
+++ b/microLiquidCrystal_I2C/microLiquidCrystal_I2C.h
@@ -119,14 +119,14 @@ private:
   void write4bits(uint8_t);
   void expanderWrite(uint8_t);
   void pulseEnable(uint8_t);
-  uint8_t _Addr;
-  uint8_t _displayfunction;
-  uint8_t _displaycontrol;
-  uint8_t _displaymode;
-  uint8_t _numlines;
-  uint8_t _cols;
-  uint8_t _rows;
-  uint8_t _backlightval;
+  uint8_t _Addr = 0;
+  uint8_t _displayfunction = 0;
+  uint8_t _displaycontrol = 0;
+  uint8_t _displaymode = 0;
+  uint8_t _numlines = 0;
+  uint8_t _cols = 0;
+  uint8_t _rows = 0;
+  uint8_t _backlightval = 0;
 };
 
 #endif


### PR DESCRIPTION
Изменения применимы для следующих классов:
* `GyverBME280`;
* `GMotor`;
* `Encoder`;
* `GyverTM1637`;
* `LiquidCrystal_I2C`.