### PR TITLE
Улучшение GTimer: "готов на старте" и экономия на "бульках"

### DIFF
--- a/GyverTimer/GyverTimer.h
+++ b/GyverTimer/GyverTimer.h
@@ -3,7 +3,6 @@
 
 /*
 	GTimer - полноценный таймер на базе системных millis() / micros()
-	Документация: https://alexgyver.ru/gyvertimer/
 	- Миллисекундный и микросекундный таймер
 	- Два режима работы:
 		- Режим интервала: таймер "срабатывает" каждый заданный интервал времени
@@ -40,32 +39,51 @@ enum timerType {
 // ============== GTimer (микросекундный и миллисекундный таймер) ================
 class GTimer {
   public:
-	GTimer(timerType type = MS, uint32_t interval = 0);	// объявление таймера с указанием типа и интервала (таймер не запущен, если не указывать)
-	void setInterval(uint32_t interval);	// установка интервала работы таймера (также запустит и сбросит таймер) - режим интервала
-	void setTimeout(uint32_t timeout);		// установка таймаута работы таймера (также запустит и сбросит таймер) - режим таймаута
-	boolean isReady();						// возвращает true, когда пришло время
-	boolean isEnabled();					// вернуть состояние таймера (остановлен/запущен)
-	void reset();							// сброс таймера на установленный период работы
-	void start();							// запустить/перезапустить (со сбросом счёта)
-	void stop();							// остановить таймер (без сброса счёта)	
-	void resume();							// продолжить (без сброса счёта)	
+	GTimer(const timerType &type = MS, const uint32_t &interval = 0, const boolean &readyOnStart = false);	// объявление таймера с указанием типа и интервала (таймер не запущен, если не указывать)
+	void setInterval(const uint32_t &interval);	// установка интервала работы таймера (также запустит и сбросит таймер) - режим интервала
+	void setTimeout(const uint32_t &timeout);	// установка таймаута работы таймера (также запустит и сбросит таймер) - режим таймаута
+	void setReadyOnStart(const boolean &readyOnStart);	// установка нулевой готовности таймера (поменяет на ИНТЕРВАЛ, запустит и сбросит таймер)
+	uint32_t getInterval();				// возвращает значение текущего интервала/таймаунта
+	boolean isReady();					// возвращает true, когда пришло время
+	boolean isEnabled();				// вернуть состояние таймера (остановлен/запущен)
+	void reset();						// сброс таймера на установленный период работы
+	void start();						// запустить/перезапустить (со сбросом счёта)
+	void stop();						// остановить таймер (без сброса счёта)	
+	void resume();						// продолжить (без сброса счёта)	
 	
 	// служебное
-	void setMode(boolean mode);				// установка режима работы вручную: AUTO или MANUAL (TIMER_INTERVAL / TIMER_TIMEOUT)
+	void setMode(const boolean &mode);	// установка режима работы вручную: AUTO или MANUAL (TIMER_INTERVAL / TIMER_TIMEOUT)
 	
   private:
 	uint32_t _timer = 0;
 	uint32_t _interval = 0;
 	uint32_t _resumeBuffer = 0;
-	boolean _mode = true;
-	boolean _state = false;
-	boolean _type = true;
+	// boolean _mode = true;				// AUTO или MANUAL
+	// boolean _state = false;				// запущен или остановлен
+	// boolean _type = true;				// MS или US
+	// boolean _readyOnStart = false;		// будет ли "готов" сразу же после запуска или нет
+	// boolean _justStarted = false;		// триггер на "готовность" сразу после старта
+	byte flags = 0b00010100;			// один байт для всех "булек". биты начиная со старшего отвечают за (X - не используется):
+										// значения: [X X X _justStarted _readyOnStart _type _state _mode>]
+										// индексы:  [7 6 5      4             3         2      1      0 >]
 };
 
-#define MANUAL 0
-#define AUTO 1
-#define TIMER_TIMEOUT 0
-#define TIMER_INTERVAL 1
+#define MANUAL 			0
+#define AUTO 			1
+#define TIMER_TIMEOUT 	0
+#define TIMER_INTERVAL 	1
+
+#define GTBIT_MODE 			0
+#define GTBIT_STATE 		1
+#define GTBIT_TYPE 			2
+#define GTBIT_READYONSTART 	3
+#define GTBIT_JUSTSTARTED 	4
+
+#define flagWrite(flag, val) bitWrite(flags, flag, val)
+#define flagRead(flag) bitRead(flags, flag)
+#define flagSet(flag) bitSet(flags, flag)
+#define flagClear(flag) bitClear(flags, flag)
+
 
 
 // ================================================================================

--- a/GyverTimer/GyverTimer.h
+++ b/GyverTimer/GyverTimer.h
@@ -29,6 +29,10 @@
 	- 3.2
 		- Добавлен isEnabled
 		- Возможность не запускать таймер при создании
+	- 3.3
+		- Добавлен режим "сразу готов" (isReady == true сразу после запуска)
+		- Добавлен getInterval()
+		- Экономия памяти за счет перехода с boolean на биты
 */
 
 enum timerType {
@@ -79,10 +83,11 @@ class GTimer {
 #define GTBIT_READYONSTART 	3
 #define GTBIT_JUSTSTARTED 	4
 
-#define flagWrite(flag, val) bitWrite(flags, flag, val)
-#define flagRead(flag) bitRead(flags, flag)
-#define flagSet(flag) bitSet(flags, flag)
-#define flagClear(flag) bitClear(flags, flag)
+// Макросы для работы с флагами
+#define flagRead(flag) bitRead(flags, flag)				// получить значение флага
+#define flagSet(flag) bitSet(flags, flag)				// установить флаг в 1
+#define flagClear(flag) bitClear(flags, flag)			// установить флаг в 0
+#define flagWrite(flag, val) bitWrite(flags, flag, val)	// установить флаг в значение val
 
 
 

--- a/GyverTimer/keywords.txt
+++ b/GyverTimer/keywords.txt
@@ -17,6 +17,8 @@ GyverTimer	KEYWORD1
 
 setInterval	KEYWORD2
 setTimeout	KEYWORD2
+setReadyOnStart	KEYWORD2
+getInterval	KEYWORD2
 isReady	KEYWORD2
 isEnabled	KEYWORD2
 reset	KEYWORD2

--- a/GyverTimer/library.properties
+++ b/GyverTimer/library.properties
@@ -1,5 +1,5 @@
 name=GyverTimer
-version=3.2
+version=3.3
 author=AlexGyver <alex@alexgyver.ru>
 maintainer=AlexGyver <alex@alexgyver.ru>
 sentence=Simple timer with period/timeout modes on millis.


### PR DESCRIPTION
(1) Добавил возможность стриггерить таймер сразу же после запуска (только в режиме интервала).
Это делается либо дополнительной булькой в конструкторе: `GTimer(const timerType &type = MS, const uint32_t &interval = 0, const boolean &readyOnStart = false)`, либо методом `setReadyOnStart(const boolean &readyOnStart)`. Естественно, при перезапуске таймера он опять сработает сразу, если это не было изменено через setReadyOnStart(false).

(2) Перевёл все boolean в биты (экономия: 4 байта SRAM и 4 байта Flash на каждый таймер). Работа с ними в классе происходит через макросы _flagRead_, _flagSet_, _flagClear_ и _flagWrite_. Для пользователя библиотеки ничего не изменилось.

(3) Добавил "защиту от дурака" в `resume()`. (Раньше: повторный вызов обновлял переменную таймера, ускоряя следующий тик таймера. Теперь: если таймер запущен, ничего не происходит)

Таким образом, обратная совместимость почти полная (почти из-за (3)).

По тестам не упарывался, но погонял по всем функциям: косяков не обнаружил.