### PR TITLE
Added header guard to GyverUART.h

### DIFF
--- a/GyverUART/GyverUART.h
+++ b/GyverUART/GyverUART.h
@@ -17,6 +17,8 @@
 	Отдельное спасибо Egor 'Nich1con' Zaharov за помощь с регистрами
 */
 
+#ifndef GyverUART_h
+#define GyverUART_h
 #define USE_PRINT_H		// закомментируй, чтобы использовать gyver-вывод
 
 #pragma once
@@ -91,3 +93,4 @@ private:
 };
 
 extern GyverUart uart;
+#endif


### PR DESCRIPTION
Header guards are necessary to prevent compilation errors.
If someone switches from standard Arduino core to GyverCore and here is GyverUART.h include in code, compilation error will happen.
Header guard prevents this.

Защита заголовочных файлов необходима для предотвращения ошибок компиляции.
Если человек переключается со стандартного ядра Arduino на ядро GyverCore и использует в коде GyverUART.h, он получит ошибку компиляции.
Защита от повторного подключения устраняет эту проблему.