### PR TITLE
Поправил readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ PURPLE
 ```
 </p>
 </details>
+
 ---
 
 <a id="GyverPower"></a>

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 * [GyverPower](#GyverPower) - библиотека для управления энергопотреблением МК
 
 ### Лёгкие библиотеки
-* [GyverBME280](#GyverBME280) - лёгкая библиотека для датчика BME280
+* [GyverBME280](#microBME280) - лёгкая библиотека для датчика BME280
 * [microLED](#microLED) - ультра-лёгкая библиотека для адресных диодов
 * [microWire](#microWire) - микро библиотека для работы с i2c
 * [microDS3231](#microDS3231) - лёгкая библиотека для RTC DS3231
@@ -73,7 +73,6 @@ minimLibs это мини-библиотеки, которые не входят
 
 
 <a id="Gyver433"></a>
-
 ### Gyver433 v1.0 [СКАЧАТЬ](https://github.com/AlexGyver/GyverLibs/releases/download/Gyver433/Gyver433.zip)
 Суперлёгкая библиотека для радиомодулей 433 МГц
 - Не использует прерывания и таймеры (кроме нулевого, читает micros())
@@ -659,7 +658,7 @@ void resetStates();     // сбрасывает все is-флаги и счёт
 
 ---
 
-<a id="GyverEncoder "></a>
+<a id="GyverEncoder"></a>
 ![Logo](/logos/encLogo.png)
 ### GyverEncoder v4.9 [СКАЧАТЬ](https://github.com/AlexGyver/GyverLibs/releases/download/GyverEncoder/GyverEncoder.zip), [ДОКУМЕНТАЦИЯ](https://alexgyver.ru/encoder/)
 Библиотека для отработки энкодера с Arduino. Возможности:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GyverLibs by AlexGyver
 ## Написанные с нуля/модифицированные библиотеки для Arduino
-[![AlexGyver YouTube](http://alexgyver.ru/git_banner.jpg)](https://www.youtube.com/channel/UCgtAOyEQdAyjvm9ATCi_Aig?sub_confirmation=1)
+[![AlexGyver YouTube](https://alexgyver.ru/git_banner.jpg)](https://www.youtube.com/channel/UCgtAOyEQdAyjvm9ATCi_Aig?sub_confirmation=1)
 > Внимание! Библиотеки написаны ютубером-ардуинщиком, возможна высокая концентрация костылей и стандартных подходов. Но всё работает замечательно!
 
 ![Logo](/logos/libs.png)
@@ -1927,8 +1927,8 @@ int16_t sampleTime = 1000;          // время итерации, мс (по �
 
 ### TM74HC595_Gyver v1.1 [СКАЧАТЬ](https://github.com/AlexGyver/GyverLibs/releases/download/TM74HC595_Gyver/TM74HC595_Gyver.zip)
 Библиотека для дисплея на сдвиговике TM74HC595 с Arduino
-- Подробное описание здесь http://alexgyver.ru/tm74hc595_display/
+- Подробное описание здесь https://alexgyver.ru/tm74hc595_display/
 
 ### TM1637_Gyver v1.1
 Библиотека для дисплея на сдвиговике TM1637 с Arduino
-- Подробное описание здесь http://alexgyver.ru/tm1637_display/
+- Подробное описание здесь https://alexgyver.ru/tm1637_display/


### PR DESCRIPTION
Исправлены некоторые косяки в файле `README.md`.
## Сделано:
- Исправлены нерабочие якоря на заголовки **GyverBME280** и **GyverEncoder**;
- В ссылках протокол `http` заменен на `https`;
- Немного поправлена разметка 