### PR TITLE
Fix warning ISO from indexof

### DIFF
--- a/minimLibs/mString/mString.h
+++ b/minimLibs/mString/mString.h
@@ -351,7 +351,7 @@ class mString {
       return (temp == NULL) ? -1 : (temp - buf);
     }
 
-    int indexOf(char* ch, uint16_t fromIndex = 0) {
+    int indexOf(const char* ch, uint16_t fromIndex = 0) {
       if (fromIndex >= length()) return -1;
       const char* temp = strstr(buf + fromIndex, ch);
       return (temp == NULL) ? -1 : (temp - buf);


### PR DESCRIPTION
Fix warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]